### PR TITLE
Renamed org in dev org def

### DIFF
--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -1,5 +1,5 @@
 {
-  "orgName": "DataGenerationToolkit - Dev Org",
+  "orgName": "Snowfakery Recipe - Dev Org",
   "edition": "Developer",
   "settings": {
     "lightningExperienceSettings": {


### PR DESCRIPTION
I noticed the org definition file still referenced the previous name.
Replaces #26 

# Changes

Updated orgs/dev.json to have a named based on current repo name, not main project.