### PR TITLE
adding temp directory with gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ robot/DataGenerationTool/results/
 .DS_Store
 
 node_modules
+snowfakery_samples/temp/


### PR DESCRIPTION

# Critical Changes

# Changes
Added temp directory so that recipes outputting json can all go to the same location and will be ignored from tracking via the gitignore file
# Issues Closed
