### PR TITLE
Feature/cci tasks and flows

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -34,15 +34,15 @@ tasks:
         group: NPSP
         class_path: cumulusci.tasks.bulkdata.generate_and_load_data_from_yaml.GenerateAndLoadDataFromYaml
         options:
-            generator_yaml: snowfakery_samples\npsp\Account_npsp.recipe.yml
+            generator_yaml: snowfakery_samples/npsp/Account_npsp.recipe.yml
 
     npsp_contact:
         class_path: cumulusci.tasks.bulkdata.generate_and_load_data_from_yaml.GenerateAndLoadDataFromYaml
         group: NPSP
         options:
-            generator_yaml: snowfakery_samples\npsp\Contact_npsp.recipe.yml
+            generator_yaml: snowfakery_samples/npsp/Contact_npsp.recipe.yml
             
-   npsp_settings:
+    npsp_settings:
         class_path: cumulusci.tasks.bulkdata.generate_and_load_data_from_yaml.GenerateAndLoadDataFromYaml
         options:
             generator_yaml: snowfakery_samples/npsp/NPSP_Settings.recipe.yml

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -29,3 +29,15 @@ tasks:
     run_tests:
         options:
             required_org_code_coverage_percent: 75
+
+    npsp_account:
+        group: NPSP
+        class_path: cumulusci.tasks.bulkdata.generate_and_load_data_from_yaml.GenerateAndLoadDataFromYaml
+        options:
+            generator_yaml: snowfakery_samples\npsp\Account_npsp.recipe.yml
+
+    npsp_contact:
+        class_path: cumulusci.tasks.bulkdata.generate_and_load_data_from_yaml.GenerateAndLoadDataFromYaml
+        group: NPSP
+        options:
+            generator_yaml: snowfakery_samples\npsp\Contact_npsp.recipe.yml

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -41,3 +41,11 @@ tasks:
         group: NPSP
         options:
             generator_yaml: snowfakery_samples\npsp\Contact_npsp.recipe.yml
+
+flows:
+    npsp_org:
+        steps:
+            1:
+                task: npsp_account
+            2:
+                task: npsp_contact


### PR DESCRIPTION

# Critical Changes
Creates sample tasks and flows that wrap the long strings of things like `cci task run generate_and_run_from_yaml -o generator_yaml accountrecipe.yml` to become `cci task run npsp_account`
# Changes

# Issues Closed

Fixes #24 